### PR TITLE
Replace requests with pycurl-requests

### DIFF
--- a/rave_python/rave_base.py
+++ b/rave_python/rave_base.py
@@ -1,4 +1,4 @@
-import os, hashlib, warnings, requests, json
+import os, hashlib, warnings, pycurl_requests as requests, json
 from rave_python.rave_exceptions import ServerError, RefundError
 import base64
 from Crypto.Cipher import DES3

--- a/rave_python/rave_bills.py
+++ b/rave_python/rave_bills.py
@@ -1,4 +1,4 @@
-import json, requests, copy
+import json, pycurl_requests as requests, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete
 from rave_python.rave_exceptions import ServerError, IncompleteCardDetailsError, BillCreationError, BillStatusError

--- a/rave_python/rave_ebills.py
+++ b/rave_python/rave_ebills.py
@@ -1,4 +1,4 @@
-import json, requests, copy
+import json, pycurl_requests as requests, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete
 from rave_python.rave_exceptions import ServerError, IncompleteCardDetailsError, BillCreationError, BillStatusError

--- a/rave_python/rave_payment.py
+++ b/rave_python/rave_payment.py
@@ -1,4 +1,4 @@
-import requests, json, copy
+import pycurl_requests as requests, json, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_exceptions import RaveError, IncompletePaymentDetailsError, AuthMethodNotSupportedError, TransactionChargeError, TransactionVerificationError, TransactionValidationError, ServerError, RefundError, PreauthCaptureError
 from rave_python.rave_misc import checkIfParametersAreComplete

--- a/rave_python/rave_paymentplan.py
+++ b/rave_python/rave_paymentplan.py
@@ -1,4 +1,4 @@
-import requests, json, copy
+import pycurl_requests as requests, json, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete, generateTransactionReference
 from rave_python.rave_exceptions import  ServerError, IncompletePaymentDetailsError, PlanCreationError, PlanStatusError

--- a/rave_python/rave_preauth.py
+++ b/rave_python/rave_preauth.py
@@ -1,4 +1,4 @@
-import requests
+import pycurl_requests as requests
 import json
 from rave_python.rave_exceptions import ServerError, TransactionVerificationError, PreauthCaptureError, PreauthRefundVoidError
 from rave_python.rave_card import Card

--- a/rave_python/rave_recepient.py
+++ b/rave_python/rave_recepient.py
@@ -1,4 +1,4 @@
-import json, requests, copy
+import json, pycurl_requests as requests, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete
 from rave_python.rave_exceptions import ServerError, IncompleteCardDetailsError, RecepientCreationError, RecepientStatusError

--- a/rave_python/rave_recipient.py
+++ b/rave_python/rave_recipient.py
@@ -1,4 +1,4 @@
-import json, requests, copy
+import json, pycurl_requests as requests, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete
 from rave_python.rave_exceptions import ServerError, IncompleteCardDetailsError, RecipientCreationError, RecipientStatusError

--- a/rave_python/rave_settlement.py
+++ b/rave_python/rave_settlement.py
@@ -1,4 +1,4 @@
-import json, requests, copy
+import json, pycurl_requests as requests, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete
 from rave_python.rave_exceptions import ServerError, IncompleteCardDetailsError, CardCreationError, CardStatusError

--- a/rave_python/rave_subaccounts.py
+++ b/rave_python/rave_subaccounts.py
@@ -1,4 +1,4 @@
-import requests, json, copy
+import pycurl_requests as requests, json, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete, generateTransactionReference
 from rave_python.rave_exceptions import  ServerError, IncompletePaymentDetailsError, SubaccountCreationError, PlanStatusError

--- a/rave_python/rave_subscription.py
+++ b/rave_python/rave_subscription.py
@@ -1,4 +1,4 @@
-import requests, json, copy
+import pycurl_requests as requests, json, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete, generateTransactionReference
 from rave_python.rave_exceptions import  ServerError, IncompletePaymentDetailsError, PlanCreationError, PlanStatusError

--- a/rave_python/rave_transfer.py
+++ b/rave_python/rave_transfer.py
@@ -1,4 +1,4 @@
-import requests, json, copy
+import pycurl_requests as requests, json, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete, generateTransactionReference, checkTransferParameters
 from rave_python.rave_exceptions import InitiateTransferError, ServerError, TransferFetchError, IncompletePaymentDetailsError

--- a/rave_python/rave_verify.py
+++ b/rave_python/rave_verify.py
@@ -1,4 +1,4 @@
-import json, requests, copy
+import json, pycurl_requests as requests, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete
 from rave_python.rave_exceptions import ServerError, BVNFetchError

--- a/rave_python/rave_virtualaccount.py
+++ b/rave_python/rave_virtualaccount.py
@@ -1,4 +1,4 @@
-import json, requests, copy
+import json, pycurl_requests as requests, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete
 from rave_python.rave_exceptions import ServerError, IncompleteAccountDetailsError, AccountCreationError, AccountStatusError

--- a/rave_python/rave_virtualcard.py
+++ b/rave_python/rave_virtualcard.py
@@ -1,4 +1,4 @@
-import json, requests, copy
+import json, pycurl_requests as requests, copy
 from rave_python.rave_base import RaveBase
 from rave_python.rave_misc import checkIfParametersAreComplete
 from rave_python.rave_exceptions import ServerError, IncompleteCardDetailsError, CardCreationError, CardStatusError

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setuptools.setup(
     ),
     install_requires = [
         'pycryptodome',
-        'requests'
+        'pycurl-requests>=0.1.1'
     ]
 )


### PR DESCRIPTION
#### Description
Replaced requests with pycurl-requests.

#### Motivation and Context
"The requests library is broken in many ways as to be useless for any server that is strict or slightly non-conforming. There are requests that work perfectly fine with curl but that get rejected when made with the requests library due to its various unnecessary sanitizing"

Encountered delays in response at several times with an instance of trying to get balance while in server. Was also unable to create a connection reliably using HTTPS. Such delays weren't experienced while using cURL to make request from the server.

@Flutterwave/Corvus97 What do you think about these updates?
